### PR TITLE
no clear local variables when build buffer

### DIFF
--- a/widget-mvc.el
+++ b/widget-mvc.el
@@ -140,7 +140,6 @@ This function kills the old buffer if it exists."
   (let ((tmpl-src (wmvc:context-template context))
         (model (wmvc:context-model context)))
     (with-current-buffer buffer
-      (kill-all-local-variables)
       (setf (wmvc:context-widget-map context) nil)
       (let ((inhibit-read-only t))
         (erase-buffer))


### PR DESCRIPTION
`customize-group`などで生成されるバッファでは、`widget-button-face`などを
バッファローカルにして設定しているので、同じようにできるように、
`kill-all-local-variables`を実施させたくないのですが、問題ありますか？
手元でしばらく動かしていますが、特に気になる挙動は感じられないです。
