### PR TITLE
keep the input situation when validation is failed

### DIFF
--- a/widget-mvc.el
+++ b/widget-mvc.el
@@ -316,6 +316,7 @@ This function kills the old buffer if it exists."
                 collect (cons name result))))
     (when fails
       (wmvc:context-attr-set ctx 'error fails)
+      (setf (wmvc:context-model ctx) model)
       (wmvc:reload-buffer ctx)
       (throw 'fail nil))))
 


### PR DESCRIPTION
現状だと、`wmvc:validate-fields`でvalidationが失敗した時、
modelを更新しないで`wmvc:reload-buffer`しているので、入力内容が消えてしまいます。
