### PR TITLE
guard other variables from the effect of setf

### DIFF
--- a/widget-mvc.el
+++ b/widget-mvc.el
@@ -116,12 +116,13 @@ This function kills the old buffer if it exists."
 (defstruct wmvc:context lang template model validations widget-map action-map attributes)
 
 (defun wmvc:context-attr-set (context name value)
-  (let ((attrs (wmvc:context-attributes context)))
-    (cond
-     ((assq name attrs)
-      (let ((pair (assq name attrs)))
-        (setf (cdr pair) value)))
-     (t (setq attrs (cons (cons name value) attrs))))
+  (let ((attrs (loop for (k . v) in (wmvc:context-attributes context)
+                     if (eq k name)
+                     collect (cons k value)
+                     else
+                     collect (cons k v))))
+    (when (not (assq name attrs))
+      (setq attrs (cons (cons name value) attrs)))
     (setf (wmvc:context-attributes context) attrs)))
 
 (defun wmvc:context-attr-get (context name)
@@ -295,7 +296,7 @@ This function kills the old buffer if it exists."
 
 (defun wmvc:bind-from-widgets (context)
   (loop with widget-map = (wmvc:context-widget-map context)
-        with model = (wmvc:context-model context)
+        with model = (copy-alist (wmvc:context-model context))
         for (name . widget) in widget-map
         for pair = (assq name model)
         if pair


### PR DESCRIPTION
alistの内容を`setf`で変更すると、引数で渡した側の変数の内容も変更されてしまいます。
例えば、以下のようになってしまうので、
現状だと、`wmvc:build-buffer`に渡す変数を`copy-alist`などで守る必要が出てきます。

``` lisp
(let* ((attrs '((hoge . "aaaa")
                (fuga . "bbbb")))
       (ctx (make-wmvc:context :attributes attrs))
       testv)
  (setq testv attrs)
  (wmvc:context-attr-set ctx 'fuga "cccc")
  attrs                          ; => ((hoge . "aaaa") (fuga . "cccc"))
  testv                          ; => ((hoge . "aaaa") (fuga . "cccc"))
  (wmvc:context-attributes ctx)) ; => ((hoge . "aaaa") (fuga . "cccc"))
```

仮に、この挙動を把握して実装されていたとしても、
(elispに対しての理解が浅い)ユーザ側に対して優しくない設計だと思うので、
`setf`による変更が外部に波及しないようにしました。

`wmvc:context-attr-set`で、`copy-alist`を使っていないのは、その方が
論理的に処理に沿っているし、メモリ消費的にも良いのではと思ったので。
