### PR TITLE
update a format setting of select widget

### DIFF
--- a/widget-mvc.el
+++ b/widget-mvc.el
@@ -240,22 +240,23 @@ This function kills the old buffer if it exists."
   (let ((options (plist-get elm-plist ':options))
         (title   (or (plist-get elm-plist ':title) "select"))
         (format  (or (plist-get elm-plist ':format) "[%[%t%]] %v"))
+        (void    (or (plist-get elm-plist ':void) '(item :format "*Not Selected*")))
         (help-echo (or (plist-get elm-plist ':help-echo)
                        (wmvc:get-text context 'input-select-click-to-choose))))
     (widget-create
      'menu-choice
-     :format format :tag title :help-echo help-echo
+     :format format :tag title :help-echo help-echo :void void
      :args
      (cond
       ((consp (car options))
        (loop for i in options
              for (item-title . value) = i
              collect
-             (list 'item ':tag item-title ':value value)))
+             (list 'item ':tag item-title ':value value ':format "%t")))
       (t
        (loop for i in options
              collect
-             (list 'item ':tag (format "%s" i) ':value i)))))))
+             (list 'item ':tag (format "%s" i) ':value i ':format "%t")))))))
 
 (wmvc:lang-register-messages 't '(input-select-click-to-choose "Click to choose"))
 (wmvc:lang-register-messages 'Japanese '(input-select-click-to-choose "クリックして選択"))


### PR DESCRIPTION
menu-choiceの要素のitemは、デフォルトでformatが`%t\n`のため、現状だと改行が入ってしまいます。
また、未選択の時、`nil`と表示されるのもどうかと思ったので、未選択時の値のために`:void`引数を追加しました。
