### PR TITLE
update a format setting of radio widget

### DIFF
--- a/widget-mvc.el
+++ b/widget-mvc.el
@@ -220,21 +220,31 @@ This function kills the old buffer if it exists."
 (defun wmvc:tmpl-make-widget-input-radio (elm-plist context)
   (let ((options (plist-get elm-plist ':options))
         (indent (or (plist-get elm-plist ':indent)
-                    (current-column))))
+                    (current-column)))
+        (format  (or (plist-get elm-plist ':format) "%b%v"))
+        (horizontal (plist-get elm-plist ':horizontal)))
     (widget-create
      'radio-button-choice
-     :indent indent
+     :indent (if horizontal 0 indent) :entry-format format
      :args
      (cond
       ((consp (car options))
-       (loop for i in options
+       (loop for i = (pop options)
+             while i
              for (item-title . value) = i
+             for format = (cond ((and horizontal (car options)) "%t ")
+                                ((car options)                  "%t\n")
+                                (t                              "%t"))
              collect
-             (list 'item ':tag item-title ':value value)))
+             (list 'item ':tag item-title ':value value ':format format)))
       (t
-       (loop for i in options
+       (loop for i = (pop options)
+             while i
+             for format = (cond ((and horizontal (car options)) "%t ")
+                                ((car options)                  "%t\n")
+                                (t                              "%t"))
              collect
-             (list 'item ':tag (format "%s" i) ':value i)))))))
+             (list 'item ':tag (format "%s" i) ':value i ':format format)))))))
 
 (defun wmvc:tmpl-make-widget-input-select (elm-plist context)
   (let ((options (plist-get elm-plist ':options))


### PR DESCRIPTION
radio-button-choiceの要素のitemは、デフォルトのformatが`%t\n`なので、
現状だと、radio-button-choice全体の最後に改行が入ってしまうので、
最後の要素のみ、改行が入らないようにしました。

また、formatを指定できるようにして、
未指定だと`%b %v`なのですが、空白無しの方が見た目良いかなと思ったので、デフォルトは`%b%v`にしました。

また、各要素を1行に並ばせたい時があるので、`:horizontal`引数を追加しました。
